### PR TITLE
Use pipe character instead of border-right to separate footer links

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,11 +212,9 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
           >Copyright &copy; 2019 Bitcamp. All Rights Reserved.</span
         >
         <span id="links">
-          <a class="border-right" href="http://mlh.io/code-of-conduct"
-            >MLH Code of Conduct</a
-          >
-          <a class="border-right" href="./sponsorship.pdf">Sponsor Us</a>
-          <a class="border-right" href="./brand.pdf">Brand Guidelines</a>
+          <a href="http://mlh.io/code-of-conduct">MLH Code of Conduct</a> | 
+          <a href="./sponsorship.pdf">Sponsor Us</a> | 
+          <a href="./brand.pdf">Brand Guidelines</a> | 
           <a href="mailto:hello@bit.camp">Contact Us</a>
         </span>
       </footer>

--- a/styles.css
+++ b/styles.css
@@ -253,11 +253,6 @@ footer a:hover {
   border-bottom: thin solid #595959; /* Bottom border transitions to same color as text */
 }
 
-.border-right {
-  border-right: 1px solid #b2b2b2;
-  padding-right: 3px;
-}
-
 #mc-embedded-subscribe {
   color: #ffffff;
   background: #ff6f3f;


### PR DESCRIPTION
Fixes the incorrect spacing

Before:
![image](https://user-images.githubusercontent.com/14797288/73903315-c8be4c00-4866-11ea-8fb8-55d51748ee16.png)

After:
![image](https://user-images.githubusercontent.com/14797288/73903328-cc51d300-4866-11ea-8455-d22f7e400b4e.png)